### PR TITLE
fix: activate portal backend on demand

### DIFF
--- a/misc/org.freedesktop.impl.portal.desktop.tty.service
+++ b/misc/org.freedesktop.impl.portal.desktop.tty.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.desktop.tty
+Exec=/usr/lib/portty/porttyd
+SystemdService=portty.service

--- a/misc/portty.service
+++ b/misc/portty.service
@@ -4,11 +4,9 @@ PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]
-Type=simple
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.tty
 ExecStart=/usr/lib/portty/porttyd
 Restart=on-failure
 RestartSec=5
-
-[Install]
-WantedBy=default.target
-WantedBy=graphical-session.target
+Slice=session.slice


### PR DESCRIPTION
## Summary
- switch `portty.service` from a login-started user service to a D-Bus activated backend
- add a D-Bus service file for `org.freedesktop.impl.portal.desktop.tty`
- avoid starting `porttyd` before the graphical session environment is available

## Why
Starting `porttyd` at login can happen before the user session environment is fully available, which causes spawned terminals like `kitty` to fail until `portty.service` is manually restarted. Starting the backend on first D-Bus request fixes that timing issue and matched local testing on Hyprland.

## Testing
- reproduced the bug locally on Hyprland: after reboot, `portty.service` started at login but file picker requests failed until `systemctl --user restart portty.service`
- observed these errors in `journalctl --user -u portty.service -b` during the failing case:
  ```text
  [glfw error 65544]: X11: The DISPLAY environment variable is missing
  GLFW initialization failed
  ```
- confirmed the failing login-started `porttyd` process was missing graphical session variables, while a manually restarted process inherited them
- installed the patched files locally by copying `misc/portty.service` to `~/.config/systemd/user/portty.service` and `misc/org.freedesktop.impl.portal.desktop.tty.service` to `~/.local/share/dbus-1/services/`
- removed the `portty.service` symlinks from `~/.config/systemd/user/default.target.wants/` and `~/.config/systemd/user/graphical-session.target.wants/`, then reloaded the user manager and rebooted
- verified `portty.service` stayed inactive until the first portal request, then started on demand via D-Bus activation
- verified the activated `porttyd` process inherited `DISPLAY`, `WAYLAND_DISPLAY`, `XDG_CURRENT_DESKTOP`, and `HYPRLAND_INSTANCE_SIGNATURE`
- confirmed the file picker worked without manually restarting `portty.service`

Related to #6